### PR TITLE
Fix circle rotation integrity and add test

### DIFF
--- a/models/model.py
+++ b/models/model.py
@@ -51,10 +51,12 @@ def on_click(event):
         if dist <= RADIO:
             print(f'Clic en círculo {i}, rotando colores...')
             circulos[i]['colores'] = circulos[i]['colores'][-1:] + circulos[i]['colores'][:-1]
+            circulos[i]['puntos'] = circulos[i]['puntos'][-1:] + circulos[i]['puntos'][:-1]
             dibujar()
             break
 
-fig.canvas.mpl_connect('button_press_event', on_click)
 
-dibujar()
-plt.show()
+if __name__ == "__main__":
+    fig.canvas.mpl_connect('button_press_event', on_click)
+    dibujar()
+    plt.show()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import matplotlib
+
+# Use a non-interactive backend for tests
+matplotlib.use("Agg")
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from models import model
+
+
+class DummyEvent:
+    def __init__(self, x, y, axes):
+        self.xdata = x
+        self.ydata = y
+        self.inaxes = axes
+
+
+def test_on_click_rotates_points_and_colors():
+    circle = model.circulos[0]
+    initial_colors = circle["colores"].copy()
+    initial_points = circle["puntos"].copy()
+
+    event = DummyEvent(circle["centro"][0], circle["centro"][1], model.ax)
+    model.on_click(event)
+
+    assert circle["colores"] == initial_colors[-1:] + initial_colors[:-1]
+    assert circle["puntos"] == initial_points[-1:] + initial_points[:-1]
+


### PR DESCRIPTION
## Summary
- Keep point coordinates in sync with color order when a circle is rotated
- Guard plotting code under `__main__` so module can be safely imported
- Add regression test for rotation of points and colors

## Testing
- `pytest tests/test_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7252bba5c8323aafe12184bb72d80